### PR TITLE
修改 Debian 11 的源地址

### DIFF
--- a/pvetools.sh
+++ b/pvetools.sh
@@ -150,8 +150,8 @@ a | A )
     deb-src https://mirrors.ustc.edu.cn/debian/ $sver-updates main contrib non-free
     deb https://mirrors.ustc.edu.cn/debian/ $sver-backports main contrib non-free
     deb-src https://mirrors.ustc.edu.cn/debian/ $sver-backports main contrib non-free
-    deb https://mirrors.ustc.edu.cn/debian-security/ $sver/updates main contrib non-free
-    deb-src https://mirrors.ustc.edu.cn/debian-security/ $sver/updates main contrib non-free" > /etc/apt/sources.list
+    deb https://mirrors.ustc.edu.cn/debian-security/ $sver-security main contrib non-free
+    deb-src https://mirrors.ustc.edu.cn/debian-security/ $sver-security main contrib non-free" > /etc/apt/sources.list
             #修改pve 5.x更新源地址为非订阅更新源，不使用企业订阅更新源。
             echo "deb http://mirrors.ustc.edu.cn/proxmox/debian/pve/ $sver pve-no-subscription" > /etc/apt/sources.list.d/pve-no-sub.list
             #关闭pve 5.x企业订阅更新源


### PR DESCRIPTION
修改 Debian 11 的源地址，官方修改见 https://www.debian.org/releases/bullseye/amd64/release-notes/ch-information.html