### PR TITLE
fix pve 7.2-3, 配置PCI设备直通--配置开启物理机硬件直通支持

### DIFF
--- a/pvetools.sh
+++ b/pvetools.sh
@@ -2062,7 +2062,7 @@ getVideo(){
     n=`for i in $id;do lspci -n -d $i|awk -F "." '{print $1}';done|sort -u`
     for i in $n
     do
-        sed -i "$i/s/OFF/ON/" cards
+        sed -i "/${i}/s/OFF/ON/" cards
     done
     DISTROS=$(whiptail --title "Video cards:" --checklist \
 "Choose cards to config(* mark means configed):

--- a/pvetools.sh
+++ b/pvetools.sh
@@ -2062,13 +2062,13 @@ getVideo(){
     n=`for i in $id;do lspci -n -d $i|awk -F "." '{print $1}';done|sort -u`
     for i in $n
     do
-        cards=`sed -n '/'$i'/ s/OFF/ON/p' cards`
+        sed -i "$i/s/OFF/ON/" cards
     done
     DISTROS=$(whiptail --title "Video cards:" --checklist \
 "Choose cards to config(* mark means configed):
 选择显卡（标*号为已经配置过的）：
 " 15 90 4 \
-$(echo $cards) \
+$(cat cards) \
 3>&1 1>&2 2>&3)
     exitstatus=$?
     if [ $exitstatus = 0 ];then
@@ -2113,7 +2113,7 @@ Continue?
             if [ `find /sys/kernel/iommu_groups/ -type l|wc -l` = 0 ];then
                 if [ `grep 'pcie_acs_override=downstream' /etc/default/grub|wc -l` = 0 ];then
                     getIommu
-                    sed -i.bak "s|iommu=on|$iommu|" /etc/default/grub
+                    sed -i.bak "s|quiet|quiet $iommu|" /etc/default/grub
                     update-grub
                 fi
             fi

--- a/pvetools.sh
+++ b/pvetools.sh
@@ -2073,7 +2073,7 @@ $(cat cards) \
     exitstatus=$?
     if [ $exitstatus = 0 ];then
         #--config-id---
-        if [ $DISTROS ];then
+        if [ -n "$DISTROS" ];then
 	    rm cards*
             if(whiptail --title "Warnning" --yesno "
 Continue?


### PR DESCRIPTION
grep: iommu=pt: no such file or directory
grep: pcie_acs_override=downstream: no such file or directory 
sed -e error